### PR TITLE
faker back in prod environment

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "express": "^4.16.4",
     "express-paginate": "^1.0.0",
     "express-session": "^1.15.1",
+    "faker": "^4.1.0",
     "history": "^4.9.0",
     "morgan": "^1.9.1",
     "nodemailer": "^6.3.1",


### PR DESCRIPTION
To be able to seed heroku prod env - we need faker in dependencies